### PR TITLE
Fixed colouring of git branch

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -34,27 +34,27 @@ HISTFILESIZE=2000
 PROMPT_COMMAND='history -a'   # share history across all terminals
 
 # regular colors
-BLACK="\[\033[0;30m\]"
-RED="\[\033[0;31m\]"
-GREEN="\[\033[0;32m\]"
-YELLOW="\[\033[0;33m\]"
-BLUE="\[\033[0;34m\]"
-MAGENTA="\[\033[0;35m\]"
-CYAN="\[\033[0;36m\]"
-WHITE="\[\033[0;37m\]"
+BLACK="\033[0;30m"
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+BLUE="\033[0;34m"
+MAGENTA="\033[0;35m"
+CYAN="\033[0;36m"
+WHITE="\033[0;37m"
 
 # emphasized (bolded) colors
-BBLACK="\[\033[1;30m\]"
-BRED="\[\033[1;31m\]"
-BGREEN="\[\033[1;32m\]"
-BYELLOW="\[\033[1;33m\]"
-BBLUE="\[\033[1;34m\]"
-BMAGENTA="\[\033[1;35m\]"
-BCYAN="\[\033[1;36m\]"
-BWHITE="\[\033[1;37m\]"
+BBLACK="\033[1;30m"
+BRED="\033[1;31m"
+BGREEN="\033[1;32m"
+BYELLOW="\033[1;33m"
+BBLUE="\033[1;34m"
+BMAGENTA="\033[1;35m"
+BCYAN="\033[1;36m"
+BWHITE="\033[1;37m"
 
 # reset
-RESET="\[\033[0;37m\]"
+RESET="\033[0;0m"
   
 TEXT_USERNAME='\u'
 TEXT_AT=' at '
@@ -63,24 +63,35 @@ TEXT_IN=' in '
 TEXT_WORKING_DIRECTORY='\w'
 
 if [ "$UID" == 0 ] || [ $TEXT_USERNAME == "root" ] ; then
-    COLOR_USERNAME=$BRED
+    COLOR_USERNAME="\[$BRED\]"
 else
-    COLOR_USERNAME=$YELLOW
+    COLOR_USERNAME="\[$YELLOW\]"
 fi
 
 if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ] ; then
-    COLOR_HOSTNAME=$BCYAN
+    COLOR_HOSTNAME="\[$BCYAN\]"
 else
-    COLOR_HOSTNAME=$BGREEN
+    COLOR_HOSTNAME="\[$BGREEN\]"
 fi
 
-COLOR_WORKING_DIRECTORY=$BYELLOW
-COLOR_BRANCH=$BMAGENTA #todo
+COLOR_WORKING_DIRECTORY="\[$BYELLOW\]"
+COLOR_ESCAPED_RESET="\[$RESET\]"
 
 function __git_prompt {
-  GIT_PS1_SHOWDIRTYSTATE=1
-  __git_ps1 "%s" | sed 's/ \([+*]\{1,\}\)$/\1/' | sed 's/^/ on /g'
+	GIT_CHANGES_COLOUR=$RED
+	GIT_NOCHANGES_COLOUR=$GREEN
+
+	GIT_PS1_SHOWDIRTYSTATE=1
+	
+	# The general gist of the following sed command is as follows:
+	# 1. Exploit the fact that git branches can't have spaces. So search for a string which does not have a space.
+	# 1.1. If this matches, set colour to NOCHANGES, insert capture and skip to end of commands.
+	# 2. Failing previous test, assume that the repo has changes because a space has been found, which indicates a following change state marker.
+	# 2.2. Remove change markers as we're using colourisation to show the change state.
+	# 3. Insert the full output and prefix the CHANGES colour.
+	__git_ps1 "%s" | sed -e "s/^\([^ ]\{1,\}\)$/ on $(printf $GIT_NOCHANGES_COLOUR)\1/;t" -e "s/ [*+#]\{1,\}//" -e "s/^/ on $(printf $GIT_CHANGES_COLOUR)/"
 }
 
-PS1="$COLOR_USERNAME$TEXT_USERNAME$RESET$TEXT_AT$COLOR_HOSTNAME$TEXT_HOSTNAME$RESET$TEXT_IN$COLOR_WORKING_DIRECTORY$TEXT_WORKING_DIRECTORY$RESET\$(__git_prompt)$RESET\n$ "
+PS1="$COLOR_USERNAME$TEXT_USERNAME$COLOR_ESCAPED_RESET$TEXT_AT$COLOR_HOSTNAME$TEXT_HOSTNAME$COLOR_ESCAPED_RESET\
+$TEXT_IN$COLOR_WORKING_DIRECTORY$TEXT_WORKING_DIRECTORY$COLOR_ESCAPED_RESET\$(__git_prompt)$COLOR_ESCAPED_RESET\n$ "
 PS2="#═> "


### PR DESCRIPTION
Hey man! Fixed up your .bashrc file as I wanted to do something similar :).

### Changes
* Removed escape characters from colour codes so they can be used via
printf.
* Fixed reset colour code to actually reset.
* Moved colour escapes to COLOR_* variables.
* Updated sed command to nicely colour the git branch (that regex took a
while!)